### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,5 +1,9 @@
 name: Restyled
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/AdmiraList/security/code-scanning/3](https://github.com/LanikSJ/AdmiraList/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it appears that the workflow needs `contents: read` and `pull-requests: write` permissions. These permissions will allow the workflow to read repository contents and create or update pull requests as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
