### PR TITLE
Potential fix for code scanning alert no. 8: Checkout of untrusted code in trusted context

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Setup Restyled
         uses: restyled-io/actions/setup@99baa06083ca10257935292eb03fe8ceae58a1eb # v4.4.9
       - name: Run Restyled
@@ -59,7 +57,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Setup Restyled
         uses: restyled-io/actions/setup@99baa06083ca10257935292eb03fe8ceae58a1eb # v4.4.9
       - name: Run Restyled


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/AdmiraList/security/code-scanning/8](https://github.com/LanikSJ/AdmiraList/security/code-scanning/8)

In general, to fix this class of problem you either (1) ensure the workflow that checks out untrusted PR code is unprivileged (limited permissions, no write access to repo or secrets), or (2) avoid checking out untrusted code in the privileged workflow and instead act only on trusted state (e.g., the merge commit of the PR branch into the base). Here, we can keep a single workflow but adjust the checkout to use the trusted merge ref that GitHub creates for PRs (`refs/pull/<number>/merge`) or simply omit the explicit `ref:` override so `actions/checkout` uses the default `github.ref`, which is the merge ref in `pull_request` workflows. That way, Restyled runs on the tested merge result rather than directly on the attacker-controlled head ref.

The minimal, behavior-preserving and safe change is:
- In the `restyle-pr` job, remove the `ref: ${{ github.event.pull_request.head.ref }}` so that `actions/checkout` will default to the PR’s merge commit (`github.ref`) created by GitHub. This uses a trusted ref and avoids directly using the attacker-controlled head ref while still styling the exact code that would be merged.
- In the `restyle-fork` job, likewise remove the explicit `ref:` override, and rely on the default behavior of `actions/checkout` in `pull_request` workflows. Since we already restrict this job to forks and we’re not using `pull_request_target`, the token is unprivileged, but we still avoid directly targeting the head ref and instead use the merge ref that GitHub provides for the PR.

No new imports or external libraries are needed; we only modify the `with:` blocks for `actions/checkout` in `.github/workflows/restyled.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
