### PR TITLE
chore: Add Markdownlint and Prettier configuration files

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-    "default": true,
-    "MD013": {
-        "line_length": 120
-    },
-    "MD041": false
-}

--- a/.markdownlint.toml
+++ b/.markdownlint.toml
@@ -1,0 +1,6 @@
+default = true
+
+[MD013]
+line_length = 120
+
+MD041 = false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Ignore GitHub files from prettier formatting
+.github/
+
+# Other common ignores
+node_modules/
+dist/
+build/
+*.log
+.DS_Store

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,0 +1,4 @@
+printWidth = 140
+singleQuote = true
+semi = true
+useTabs = true


### PR DESCRIPTION
Introduce code quality and formatting configurations to maintain consistent style across the project.

- Set Markdownlint to use default rules with a 120-character line length and disable MD041
- Configure Prettier with 140-character lines, single quotes, semicolons, and tab indentation
- Add Prettier ignore patterns for common directories and files
