### PR TITLE
chore: increase max_line_length to 140 in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 80
+max_line_length = 140
 
 [*.{js,ts,jsx,tsx,json,md}]
 indent_style = space


### PR DESCRIPTION
- The line length limit was raised from 80 to 140 characters to better accommodate modern code formatting practices and improve readability for longer statements.
- This aligns the project’s editor settings with current development standards.
