### PR TITLE
chore: add .gitattributes to classify .txt files as AdBlock language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Override classification for *.txt files, so they are highlighted as adblock files.
+# By default, Adblock language doesn't show up in the repository's language statistics,
+# but adding "linguist-detectable" will resolve this.
+*.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
- This ensures that .txt files are detected as AdBlock language in repository language statistics, overriding the default classification.
